### PR TITLE
Replace 'vars' pragma

### DIFF
--- a/TOML.pm
+++ b/TOML.pm
@@ -21,8 +21,9 @@ package TOML;
 # -------------------------------------------------------------------
 
 use strict;
-use vars qw($VERSION @EXPORT);
 use base qw(Exporter);
+
+our( $VERSION, @EXPORT );
 
 use Text::Balanced qw(extract_bracketed);
 


### PR DESCRIPTION
This pragma is marked as obsolete, see http://perldoc.perl.org/vars.html.
