### PR TITLE
Better unescape

### DIFF
--- a/TOML.pm
+++ b/TOML.pm
@@ -34,7 +34,6 @@ $VERSION = "0.91";
 $SYNTAX_ERROR = q(Syntax error);
 
 my %UNESCAPE = (
-    q{0} => "\x00",
     q{b} => "\x08",
     q{t} => "\x09",
     q{n} => "\x0a",
@@ -151,7 +150,7 @@ sub from_toml {
             $val =~ s/^"//;
             $val =~ s/"$//;
             $val =~ s!
-                \\([0btnfr"/\\])
+                \\([btnfr"/\\])
                 |
                 \\u([0-9A-Fa-f]{4})
             !

--- a/t/escape.t
+++ b/t/escape.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More tests => 4;
+
+use_ok("TOML");
+
+my ($dat, $err) = from_toml(<<'...');
+all="\b\t\n\f\r\"\/\\"
+unichar="\u0022"
+...
+ok(!$err) or diag $err;
+
+is($dat->{all}, "\x08\x09\x0A\x0C\x0D\x22\x2F\x5C");
+is($dat->{unichar}, q{"});
+


### PR DESCRIPTION
- Unescape \b, \f, \/, and \uXXXX
- Removed \0 unescape(Incompatible change. But respect spec.)
